### PR TITLE
Grid Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.5.0 - 2018-11-15
+### Added
+- verticalMargin, marginTop, marginBottom flags to Grid
+- centered flag to Col
+
+### Fixed
+- media queries use px instead of em now
+
 ## 0.4.0 - 2018-11-12
 ### Added
 - PR template

--- a/src/constants/media-queries.js
+++ b/src/constants/media-queries.js
@@ -10,7 +10,7 @@ const sizes = {
 
 const media = Object.keys(sizes).reduce((acc, label) => {
   acc[label] = (...args: any[]) => css`
-    @media (min-width: ${sizes[label] / 16}em) {
+    @media (min-width: ${sizes[label]}px) {
       ${css(...args)};
     }
   `;

--- a/src/flex-grid/col/index.js
+++ b/src/flex-grid/col/index.js
@@ -16,6 +16,7 @@ type ColPropsType = {
   mdOffset?: number,
   lg: number,
   lgOffset?: number,
+  centered?: boolean,
 };
 
 const widthOfInnerMargins = `calc(11 * ${DOUBLE_GUTTER_SPACING})`;
@@ -43,6 +44,12 @@ const calculateMarginLeft = (first: boolean, offset: ?number) => {
 
 export const Col: ComponentType<ColPropsType> = styled.div`
   flex: 0 0 auto;
+  ${({ centered }) =>
+    centered &&
+    `
+      display: flex;
+      justify-content: center;
+    `}
   width: ${({ sm }) => calculateWidth(sm)};
   ${({ smFirst, smOffset }) => calculateMarginLeft(smFirst, smOffset)};
   ${media.medium`

--- a/src/flex-grid/grid/index.js
+++ b/src/flex-grid/grid/index.js
@@ -7,13 +7,26 @@ import SPACING from '../../constants/spacing';
 import MAX_WIDTH from '../../constants/max-width';
 
 type GridPropsType = {
+  // NOTE: margin is deprecated in favor of verticalMargin, marginTop, and marginBottom
+  // shouldn't ever need to adjust the horizontal margins of the grid.
   margin?: string,
+  verticalMargin?: string,
+  marginTop?: string,
+  marginBottom?: string,
 };
 
 export const Grid: ComponentType<GridPropsType> = styled.div`
   padding: 0 ${SPACING.S_4};
   ${MAX_WIDTH};
   margin: ${({ margin }) => margin || '0 auto'};
+  ${({ verticalMargin }) =>
+    verticalMargin &&
+    `
+    margin-top: ${verticalMargin};
+    margin-bottom: ${verticalMargin};
+  `};
+  ${({ marginTop }) => marginTop && `margin-top: ${marginTop};`};
+  ${({ marginBottom }) => marginBottom && `margin-bottom: ${marginBottom};`};
   width: 100%;
 `;
 


### PR DESCRIPTION
### Status
**READY**

### Description
Uses px for media queries - there was an issue where queries were firing at different times based on the font size of the parent. realized that we basically always just want these to be in px as they shouldn't change at all.

adds a `centered` flag to Col to horizontally center its contents, because that has become a common design pattern + we want to discourage extending these components on the fly

deprecates margin prop on `Grid` in favor of `verticalMargin`, `marginTop`, `marginBottom` (the more specific top and bottom are prioritized over vertical margin if for some reason all were applied at once) - this is similar reasoning as the centered flag (we shouldnt ever be messing with the grid's horizontal spacing as that's what it's there for)

