### PR TITLE
Grid breakpoint adjustment

### DIFF
--- a/src/flex-grid/col/index.js
+++ b/src/flex-grid/col/index.js
@@ -52,11 +52,11 @@ export const Col: ComponentType<ColPropsType> = styled.div`
     `}
   width: ${({ sm }) => calculateWidth(sm)};
   ${({ smFirst, smOffset }) => calculateMarginLeft(smFirst, smOffset)};
-  ${media.medium`
+  ${media.small`
     width: ${({ md }) => calculateWidth(md)};
     ${({ mdFirst, mdOffset }) => calculateMarginLeft(mdFirst, mdOffset)};
   `};
-  ${media.large`
+  ${media.medium`
     width: ${({ lg }) => calculateWidth(lg)};
     ${({ lgFirst, lgOffset }) => calculateMarginLeft(lgFirst, lgOffset)};
   `};


### PR DESCRIPTION
### Status
**READY**

### Description

I realized that we were targeting different breakpoints with the grid than Nick was designing for.

![image](https://user-images.githubusercontent.com/9433365/48854465-0036fa80-ed80-11e8-997d-2a3d59af7427.png)

before small was targeting 0-1024, medium was targeting 1024-1280, and large was 1280+

what we want based on Nick's design system is small 0-768, medium 768-1024, lg 1024+

does this make sense? i think that a point of confusion right now is that our breakpoints are mobile first so in actuality, we have four spaces that we can target

XS = 0-768
SM = 768-1024
MD = 1024-1280
LG = 1280+

but we have three grid sizes?

wondering if we're introducing lexical confusion by not making the grid consistent with the breakpoint naming that we've implicitly established in `constants/media-queries`